### PR TITLE
Fix decoding 8-bit RGB as BufferedImage

### DIFF
--- a/src/edu/uthscsa/ric/volume/formats/jpeg/JPEGLosslessDecoderWrapper.java
+++ b/src/edu/uthscsa/ric/volume/formats/jpeg/JPEGLosslessDecoderWrapper.java
@@ -63,6 +63,7 @@ public class JPEGLosslessDecoderWrapper {
 			switch(decoder.getPrecision())
 			{
 			case 24:
+                        case 8:
 				return read24Bit3ComponentRGB(decoded, width, height);
 
 			default:


### PR DESCRIPTION
I got an exception when decoding an 8-bit RGB image; it seems the Wrapper was expecting it to be 24-bit precision, not 8-bit precision. Adding the '8' case allowed it to decode properly for my use case.

I'll look into sending a followup pull request with some test data; do you have test data which worked properly with the 24-bit precision case?